### PR TITLE
fix(create-profile): ensure solid dark styles for art type select to fix Windows/Chrome contrast issue

### DIFF
--- a/app/create-profile/page.js
+++ b/app/create-profile/page.js
@@ -674,7 +674,7 @@ setMessage('Server error.');
             onChange={handleChange}
             onFocus={() => setShowArtTypeHelp(true)}
             onBlur={() => setShowArtTypeHelp(false)}
-            className="block w-full p-3 rounded-lg border border-white/20 bg-white/10 backdrop-blur-sm text-white focus:ring-2 focus:ring-cyan-400"
+            className="block w-full p-3 rounded-lg border border-cyan-700 bg-slate-900 text-cyan-100 focus:ring-2 focus:ring-cyan-400"
             required
           >
             <option value="">Select art type</option>


### PR DESCRIPTION
## Problem
The art type dropdown in the creator signup flow had low contrast on Windows/Chrome due to translucent background styling (`bg-white/10` + `text-white`). The native select dropdown options appeared blank until hovered, while Safari on Mac displayed correctly.

## Root Cause
Windows/Chrome often uses system colors for native select dropdown popups, which clashed with the translucent white-on-white styling. Safari/macOS inherits custom styling more predictably.

## Solution
- Replaced translucent select styles with solid dark styling
- Changed from `bg-white/10 text-white border-white/20` to `bg-slate-900 text-cyan-100 border-cyan-700`
- Maintains the same focus ring styling for consistency

## Testing
- Verified other selects in the codebase use appropriate solid backgrounds
- No similar contrast issues found elsewhere

## Files Changed
- `app/create-profile/page.js` - Updated art type select styling

Fixes the Windows/Chrome visibility issue while maintaining visual consistency with the rest of the form.